### PR TITLE
Fix inconsistent Option's logic when creating object and using with.

### DIFF
--- a/vavr-encodings/src/main/java/org/immutables/vavr/encodings/VavrOptionEncoding.java
+++ b/vavr-encodings/src/main/java/org/immutables/vavr/encodings/VavrOptionEncoding.java
@@ -43,7 +43,7 @@ class VavrOptionEncoding<T>
   public Option<T> with(
     final T value)
   {
-    return Option.some(value);
+    return Option.of(value);
   }
 
   @Encoding.Builder
@@ -59,16 +59,16 @@ class VavrOptionEncoding<T>
     @Encoding.Init
     @Encoding.Copy
     void set(
-      final Option<T> opt)
+      final Option<T> value)
     {
-      this.optional = opt;
+      this.optional = value;
     }
 
     @Encoding.Init
     void setValue(
-      final T x)
+      final T value)
     {
-      this.optional = Option.of(x);
+      this.optional = Option.of(value);
     }
 
     @Encoding.Naming(value = "unset*")

--- a/vavr-examples/src/test/java/org/immutables/vavr/tests/examples/ExampleOptionTest.java
+++ b/vavr-examples/src/test/java/org/immutables/vavr/tests/examples/ExampleOptionTest.java
@@ -69,4 +69,15 @@ public final class ExampleOptionTest
     final ImmutableExampleOptionType a0 = b.build();
     Assert.assertEquals(Option.none(), a0.optionalInteger());
   }
+
+  @Test
+  public void testWith() {
+    ImmutableExampleOptionType a = ImmutableExampleOptionType.builder()
+      .optionalInteger(Integer.valueOf(23))
+      .build();
+
+    ImmutableExampleOptionType a1 = a.withOptionalInteger((Integer) null);
+
+    Assert.assertEquals(Option.none(), a1.optionalInteger());
+  }
 }


### PR DESCRIPTION
Use consistent Option's logic when creating object and when using "with" generated method.

Rename Builder's parameters to be consistent with Immutables parameter names.