### PR TITLE
Require non-null values for Option typed fields,

### DIFF
--- a/vavr-encodings/src/main/java/org/immutables/vavr/encodings/VavrOptionEncoding.java
+++ b/vavr-encodings/src/main/java/org/immutables/vavr/encodings/VavrOptionEncoding.java
@@ -16,10 +16,11 @@
 
 package org.immutables.vavr.encodings;
 
-import io.vavr.control.Option;
+import java.util.Objects;
+
 import org.immutables.encode.Encoding;
 
-import java.util.Objects;
+import io.vavr.control.Option;
 
 @Encoding
 class VavrOptionEncoding<T>
@@ -43,7 +44,7 @@ class VavrOptionEncoding<T>
   public Option<T> with(
     final T value)
   {
-    return Option.some(value);
+    return Option.some(Objects.requireNonNull(value));
   }
 
   @Encoding.Builder
@@ -61,14 +62,14 @@ class VavrOptionEncoding<T>
     void set(
       final Option<T> opt)
     {
-      this.optional = opt;
+      this.optional = Objects.requireNonNull(opt);
     }
 
     @Encoding.Init
     void setValue(
       final T x)
     {
-      this.optional = Option.of(x);
+      this.optional = Option.some(Objects.requireNonNull(x));
     }
 
     @Encoding.Naming(value = "unset*")

--- a/vavr-examples/src/test/java/org/immutables/vavr/tests/examples/ExampleOptionTest.java
+++ b/vavr-examples/src/test/java/org/immutables/vavr/tests/examples/ExampleOptionTest.java
@@ -69,4 +69,36 @@ public final class ExampleOptionTest
     final ImmutableExampleOptionType a0 = b.build();
     Assert.assertEquals(Option.none(), a0.optionalInteger());
   }
+  
+  @Test(expected = NullPointerException.class)
+  public void testSetNullValue()
+  {
+    final ImmutableExampleOptionType.Builder b =
+            ImmutableExampleOptionType.builder();
+    b.optionalInteger((Integer)null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNullOption()
+  {
+    final ImmutableExampleOptionType.Builder b =
+            ImmutableExampleOptionType.builder();
+    b.optionalInteger((Option<Integer>)null);
+  }
+  
+  @Test(expected = NullPointerException.class)
+  public void testWithNull()
+  {
+    final ImmutableExampleOptionType b =
+            ImmutableExampleOptionType.builder().build();
+    b.withOptionalInteger((Integer)null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testWithNullOption()
+  {
+    final ImmutableExampleOptionType b =
+            ImmutableExampleOptionType.builder().build();
+    b.withOptionalInteger((Option<Integer>)null);
+  }
 }


### PR DESCRIPTION
 and also for directly setting an Option object as well.

This prevents Option fields being set to `Some(null)`, which is unexpected and can lead to bugs.

https://github.com/immutables/immutables-vavr/issues/27